### PR TITLE
Downgrade matplotlib to 3.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ requires-python = ">=3.10,<4.0"
 dependencies = [
     "aiohttp>=3.9.5,<4.0",
     "prometheus_client>=0.20.0,<1.0",
-    "matplotlib>=3.9.1,<4.0",
+    "matplotlib>=3.9.0,<4.0",
     "pydantic>=2.8.2,<3.0",
     "pydantic-settings>=2.3.4,<3.0",
     "requests>=2.32.3,<3.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp==3.9.5
 prometheus_client==0.20.0
-matplotlib==3.9.1
+matplotlib==3.9.0
 pydantic==2.8.2
 pydantic-settings==2.3.4
 requests==2.32.3


### PR DESCRIPTION
Version 3.9.1 of matplotlib has been yanked. We must downgrade the version to 3.9.0