### PR TITLE
upgrade version of upload artifact action

### DIFF
--- a/.github/workflows/vulnerability.yaml
+++ b/.github/workflows/vulnerability.yaml
@@ -38,6 +38,7 @@ jobs:
           name: bandit_outputs
           path: bandit_outputs.txt
           retention-days: 2
+          overwrite: true
       - name: Run safety
         run: |
           pip install -r requirements.txt
@@ -50,3 +51,4 @@ jobs:
           path: |
             insecure_report.txt
           retention-days: 2
+          overwrite: true

--- a/.github/workflows/vulnerability.yaml
+++ b/.github/workflows/vulnerability.yaml
@@ -33,7 +33,7 @@ jobs:
           # Run bandit
           bandit -r src -c pyproject.toml -o bandit_outputs.txt -f txt --skip B311
       - name: Archive bandit outputs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bandit_outputs
           path: bandit_outputs.txt
@@ -44,7 +44,7 @@ jobs:
           pip install safety
           safety check --output text --continue-on-error > insecure_report.txt
       - name: Archive safety outputs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: safety_outputs
           path: |


### PR DESCRIPTION
Artifact actions v3 will be closing down by January 30, 2025.

Update workflows to begin using v4 of the artifact actions.